### PR TITLE
Update Playbook dev-tools, browsers and base roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ For more information about Gcloud command lines read https://cloud.google.com/sd
 
 1. The following steps need to be reviewed as they will always have a `changed` status:
  * pip
- * google-chrome
- * chromedriver
  * kubernetes
  * nvm
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ For more information about Gcloud command lines read https://cloud.google.com/sd
 
 1. The following steps need to be reviewed as they will always have a `changed` status:
  * pip
- * nvm
 
 2. Configure `thefuck`
  * add `eval $(thefuck --alias)` in your `~/.zshrc`

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Tags supported:
 | printers    | Install printer drivers                                                                                          |
 | browsers    | Install Chrome and chromedriver
 | audio-tools | Install Audacity                                                                                  |
-| dev-tools   | Install jq, xq, docker, docker-compose, go, nodejs, npm, nvm, jre8, jre10, maven, clojure, leiningen, sbt, scala, kubernetes, hub and heroku  |
+| dev-tools   | Install jq, xq, docker, docker-compose, go, nodejs, npm, nvm, jre8, jre10, maven, clojure, leiningen, sbt, scala, minikube, kubectl, hub and heroku  |
 | cloud-tools | Install google-cloud-sdk                                                                                         |
 | editors     | Install vim, atom, emacs, gimp, Intellij + JetBrains Toolbox, Microsoft Visual Studio and Xmind                  |
 | media       | Install Spotify and Peek (GIF Screen recorder)                                                                   |
@@ -102,7 +102,6 @@ For more information about Gcloud command lines read https://cloud.google.com/sd
 
 1. The following steps need to be reviewed as they will always have a `changed` status:
  * pip
- * kubernetes
  * nvm
 
 2. Configure `thefuck`

--- a/aur/install-aur.sh
+++ b/aur/install-aur.sh
@@ -23,7 +23,7 @@ if [ -z "${searchResult}" ]; then
   makepkg -s --skippgpcheck
 
   # Install package
-  sudo pacman -U *xz --noconfirm
+  makepkg -si --noconfirm
 
   # Remove temporary folder
   rm -rf /tmp/${1}

--- a/group_vars/all
+++ b/group_vars/all
@@ -21,8 +21,12 @@ developer_stack:
     - hub
     - nodejs
     - npm
-    - jre8-openjdk-headless jre8-openjdk jdk8-openjdk openjdk8-doc
-    - jre11-openjdk-headless jre11-openjdk jdk11-openjdk openjdk11-doc
+    - jre8-openjdk-headless
+    - jre8-openjdk
+    - jdk8-openjdk
+    - jre11-openjdk-headless
+    - jre11-openjdk
+    - jdk11-openjdk
     - maven
     - clojure
     - scala

--- a/group_vars/all
+++ b/group_vars/all
@@ -2,8 +2,8 @@ audio_tools:
     - audacity
 
 browsers_aur:
-    - google-chrome 86.0.4240.111-1
-    - chromedriver 86.0.4240.22-1
+    - google-chrome
+    - chromedriver
 
 browser_tor:
     - mozilla-common

--- a/group_vars/all
+++ b/group_vars/all
@@ -32,11 +32,11 @@ developer_stack:
     - scala
     - sbt
     - go-pie
+    - leiningen
+    - minikube
+    - kubectl
 
 developer_stack_aur:
-    - leiningen
-    - kubernetes
-    - kubectl-bin
     - xq
 
 editors:

--- a/roles/base/tasks/ntp.yml
+++ b/roles/base/tasks/ntp.yml
@@ -14,7 +14,7 @@
 
 - name: Configure NTP client
   command: timedatectl set-ntp true
-  when: ntpStatusVar == "yes"
+  when: ntpStatusVar == "no"
   become: yes
   tags:
     - ntp

--- a/roles/browsers/tasks/main.yml
+++ b/roles/browsers/tasks/main.yml
@@ -9,11 +9,16 @@
     - tor
 
 - name: Install browsers from Arch User Repository
-  script: ../../../aur/install-aur.sh {{ item }}
+  shell: |
+    pamac build -d --no-confirm {{ item }} | grep "is up to date"
+    if [ $? != 0 ]; then
+      pamac build --no-confirm {{ item }}
+    fi
+    exit 0;
   with_items: '{{ browsers_aur }}'
-  register: install_result
-  changed_when: install_result.rc == 0
-  failed_when: install_result.rc != 0 and install_result.rc != 255
+  register: command_result
+  failed_when: command_result.rc != 0
+  changed_when: "'successfully' in command_result.stdout"
+  become: true
   tags:
-    - aur
     - browsers

--- a/roles/developer-tools/tasks/main.yml
+++ b/roles/developer-tools/tasks/main.yml
@@ -7,12 +7,19 @@
   become: yes
 
 - name: Install Developer Tools from Arch User Repository
-  script: ../../../aur/install-aur.sh {{ item }}
+  shell: |
+    pamac build -d --no-confirm {{ item }} | grep "is up to date"
+    if [ $? != 0 ]; then
+      pamac build --no-confirm {{ item }}
+    fi
+    exit 0;
   with_items: '{{ developer_stack_aur }}'
-  register: install_result
-  changed_when: install_result.rc == 0
-  failed_when: install_result.rc != 0 and install_result.rc != 255
+  register: command_result
+  failed_when: command_result.rc != 0
+  changed_when: "'successfully' in command_result.stdout"
+  become: true
   tags:
+    - dev-tools
     - aur
 
 - include: nvm.yml

--- a/roles/developer-tools/tasks/nvm.yml
+++ b/roles/developer-tools/tasks/nvm.yml
@@ -9,8 +9,12 @@
     - nvm
     - dev-tools
 
+
 - name: Install nvm
-  shell: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/{{ nvm_latest_version.tag }}/install.sh | zsh
+  shell: >
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/{{ nvm_latest_version.tag }}/install.sh | zsh
+  args:
+    creates: "{{ ansible_env.HOME }}/.nvm/nvm.sh"
   tags:
     - nvm
     - dev-tools


### PR DESCRIPTION
This is the first attempt at using `pamac`:
  https://wiki.manjaro.org/index.php/Pamac

This will allow for a more automatic approach to install Arch Linux AUR
packages, instead of having to install them manually via the
`aur/install-aur.sh` script.

I will probably review the Ansible Playbook to use `pamac` and only
revert back to the manual approach when required.