### PR TITLE
feat: add Hugo static site generator to developer stack

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -31,13 +31,8 @@ developer_stack:
     - jdk8-openjdk
     - jdk11-openjdk
     - jdk17-openjdk
+    - jdk21-openjdk
     - jq
-    - jre8-openjdk
-    - jre8-openjdk-headless
-    - jre11-openjdk
-    - jre11-openjdk-headless
-    - jre17-openjdk
-    - jre17-openjdk-headless
     - kubectl
     - kubectx
     - leiningen

--- a/group_vars/all
+++ b/group_vars/all
@@ -28,6 +28,7 @@ developer_stack:
     - go-yq
     - gradle
     - hub
+    - hugo
     - jdk8-openjdk
     - jdk11-openjdk
     - jdk17-openjdk

--- a/tests/test-roles.yml
+++ b/tests/test-roles.yml
@@ -58,11 +58,31 @@
           changed_when: false
           failed_when: false
 
+        - name: Check if Hugo is available after role
+          ansible.builtin.command: hugo version
+          register: hugo_check
+          changed_when: false
+          failed_when: false
+
+        - name: Verify Hugo can create a new site
+          ansible.builtin.command: hugo new site /tmp/hugo-test-site --force
+          register: hugo_site_test
+          changed_when: false
+          failed_when: false
+
+        - name: Clean up Hugo test site
+          ansible.builtin.file:
+            path: /tmp/hugo-test-site
+            state: absent
+          when: hugo_site_test.rc == 0
+
         - name: Report development tools status
           ansible.builtin.debug:
             msg:
               - "Docker: {{ 'available' if docker_check.rc == 0 else 'not available' }}"
               - "Go: {{ 'available' if go_check.rc == 0 else 'not available' }}"
+              - "Hugo: {{ 'available - ' + hugo_check.stdout if hugo_check.rc == 0 else 'not available' }}"
+              - "Hugo functional test: {{ 'passed' if hugo_site_test.rc == 0 else 'failed' }}"
 
     - name: Test Security Role
       tags:

--- a/tests/verify.yml
+++ b/tests/verify.yml
@@ -102,12 +102,26 @@
           failed_when: kubectl_version.rc != 0
           ignore_errors: true
 
+        - name: Check Hugo is installed
+          ansible.builtin.command: hugo version
+          register: hugo_version
+          changed_when: false
+          failed_when: hugo_version.rc != 0
+          ignore_errors: true
+
+        - name: Verify Hugo executable exists
+          ansible.builtin.stat:
+            path: /usr/bin/hugo
+          register: hugo_binary
+          ignore_errors: true
+
         - name: Display development verification results
           ansible.builtin.debug:
             msg:
               - "Docker: {{ 'installed - ' + docker_version.stdout if docker_version.rc == 0 else 'not installed' }}"
               - "Go: {{ 'installed - ' + go_version.stdout if go_version.rc == 0 else 'not installed' }}"
               - "kubectl: {{ 'installed' if kubectl_version.rc == 0 else 'not installed' }}"
+              - "Hugo: {{ 'installed - ' + hugo_version.stdout if hugo_version.rc == 0 else 'not installed' }}"
 
     - name: Verification - Security tools
       tags:


### PR DESCRIPTION
Work includes:

* feat: add Hugo static site generator to developer stack

   > Adds Hugo to the development tools with comprehensive testing and verification:
   > - Added hugo package to developer_stack in group_vars/all
   > - Implemented functional tests to verify Hugo can create new sites
   > - Added verification checks for Hugo installation and executable


* fix: remove conflicting JRE packages from developer stack

   > The JRE (Java Runtime Environment) packages conflict with JDK (Java
   > Development Kit) packages since JDK already includes the full JRE.
   > Installing both causes pacman to fail with unresolvable package conflicts.
   > 
   > Changes:
   > - Remove jre8-openjdk, jre8-openjdk-headless
   > - Remove jre11-openjdk, jre11-openjdk-headless
   > - Remove jre17-openjdk, jre17-openjdk-headless
   > - Add jdk21-openjdk to keep up with latest LTS version
   > 
   > The JDK packages provide both runtime and development tools, so no
   > functionality is lost by removing the standalone JRE packages.