### PR TITLE
fix: correct version bump arithmetic to prevent exit code failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,16 +116,16 @@ jobs:
           # Bump version
           case $BUMP_TYPE in
             major)
-              ((MAJOR++))
+              MAJOR=$((MAJOR + 1))
               MINOR=0
               PATCH=0
               ;;
             minor)
-              ((MINOR++))
+              MINOR=$((MINOR + 1))
               PATCH=0
               ;;
             patch)
-              ((PATCH++))
+              PATCH=$((PATCH + 1))
               ;;
           esac
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -172,16 +172,16 @@ bump_version() {
     # Bump according to type
     case $bump_type in
         major)
-            ((major++))
+            major=$((major + 1))
             minor=0
             patch=0
             ;;
         minor)
-            ((minor++))
+            minor=$((minor + 1))
             patch=0
             ;;
         patch)
-            ((patch++))
+            patch=$((patch + 1))
             ;;
         *)
             log_error "Invalid bump type: $bump_type"


### PR DESCRIPTION
Fixed bash arithmetic issue where incrementing zero values with ((VAR++)) returns exit code 1, causing CI to fail. Changed to VAR=$((VAR + 1)) syntax which always returns exit code 0.

This resolves the issue where commits containing both feat: and fix: types would correctly determine "minor" as the bump type but fail during execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)